### PR TITLE
bugfix: ignore specific ActiveDocument exception

### DIFF
--- a/GitExtensionsVSIX/Commands/ItemCommandBase.cs
+++ b/GitExtensionsVSIX/Commands/ItemCommandBase.cs
@@ -14,7 +14,15 @@ namespace GitExtensionsVSIX.Commands
         {
             if (!RunForSelection)
             {
-                var activeDocument = application.ActiveDocument;
+                Document activeDocument = null;
+                try
+                {
+                    activeDocument = application.ActiveDocument;
+                }
+                catch (Exception)
+                {
+                    // It can fail when there's no active document. for example - "project properties" dialog.
+                }
 
                 if (activeDocument?.ProjectItem == null)
                 {


### PR DESCRIPTION
When there's no active document. for example - "project properties" dialog, 
calling application.ActiveDocument will throw the following exception:
_The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))_

## Fixes 
An exception is displayed when clicking on 'commit' when "project properties" dialog is open.

## Proposed changes
ignore this specific exception.

## Test methodology <!-- How did you ensure quality? -->

- ran and tested multiple buttons while different 'documents' are open

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.23
- Windows 10 1909

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
